### PR TITLE
Update plugin for proper use of $wpdb class

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,5 @@ Note: Only one membership type can synchronize with one WordPress role since a W
 Be sure to test this Plugin before using it in Production Environment. Log in as that user to ensure you have been granted the appropriate role. Then take away the membership for this user in their CiviCRM record, log back in as the test user, and make sure you no longer have that role.
 This Plugin is Dependant only on CiviCRM.
 
-Note: This plugin will sync membership roles on user login and on a daily basis
+Note: This plugin will sync membership roles on user login and on a daily basis.
   

--- a/civi.php
+++ b/civi.php
@@ -7,7 +7,6 @@ $MembershipTypeDetials=civicrm_api("MembershipType","get", array (version => '3'
    $MembershipType[$values['id']] = $values['name']; 
  }
 
-
 $MembershipStatusDetials=civicrm_api("MembershipStatus","get", array (version => '3','sequential' =>'1'));
  foreach( $MembershipStatusDetials['values'] as $key => $values){
    $MembershipStatus[$values['id']] =$values['name']; 

--- a/list.php
+++ b/list.php
@@ -2,8 +2,9 @@
 require_once('civi.php');
  if(isset($_GET['q']) && $_GET['q'] == "delete" ){
     if(!empty($_GET['id'])) {
-        $table_name = $wpdb->prefix . "civi_member_sync";
-        $delete = $wpdb->get_results( "DELETE FROM $table_name WHERE `id`=".$_GET['id']);        
+        $wpdb->civi_member_sync = $wpdb->prefix . 'civi_member_sync';
+        $rid = $_GET['id'];
+        $delete = $wpdb->get_results($wpdb->prepare( "DELETE FROM $wpdb->civi_member_sync WHERE `id`= %d", $rid)) ;     
     }
  }
 $addNew_url = get_bloginfo('url')."/wp-admin/admin.php?&page=civi_member_sync/settings.php"; 
@@ -15,8 +16,8 @@ $manual_sync_url = get_bloginfo('url')."/wp-admin/admin.php?&page=civi_member_sy
 </div>
 
 <?php
-$table_name = $wpdb->prefix . "civi_member_sync";
-$select = $wpdb->get_results( " SELECT * FROM $table_name "); ?>
+$wpdb->civi_member_sync = $wpdb->prefix . 'civi_member_sync';
+$select = $wpdb->get_results($wpdb->prepare( " SELECT * FROM $wpdb->civi_member_sync " )); ?>
 <table cellspacing="0" class="wp-list-table widefat fixed users">
  <thead>
     <tr>

--- a/manual_sync.php
+++ b/manual_sync.php
@@ -51,9 +51,7 @@ if($_GET['action'] == 'confirm') {
          }
     
     ?>   
-    
-    
-    
+
     <div id="message" class="updated below-h2">
     <span><p> CiviMember Memberships and WordPress Roles have been synchronized using available rules. Note: if no association rules exist then synchronization has not been completed.</p></span>
     </div> 

--- a/settings.php
+++ b/settings.php
@@ -2,8 +2,9 @@
  require_once('civi.php'); 
  if(isset($_GET['q']) && $_GET['q'] == "edit" ){
     if(!empty($_GET['id'])) {
-        $table_name = $wpdb->prefix . "civi_member_sync";
-        $select = $wpdb->get_results( "SELECT * FROM $table_name WHERE `id` =".$_GET['id']);
+        $rid = $_GET['id'];
+        $wpdb->civi_member_sync = $wpdb->prefix . 'civi_member_sync';
+        $select = $wpdb->get_results($wpdb->prepare( "SELECT * FROM $wpdb->civi_member_sync  WHERE `id` = %d"), $rid);
         $wp_role = $select[0]->wp_role; 
         $expired_wp_role = $select[0]->expire_wp_role; 
         $civi_member_type  = $select[0]->civi_mem_type;  
@@ -157,8 +158,8 @@ if ($_POST) {
     }
     
     if(empty($sameType) && empty($errors)) {
-        $table_name = $wpdb->prefix . "civi_member_sync";    
-        $insert = $wpdb->get_results( "REPLACE INTO  $table_name SET `wp_role`='$wp_role', `civi_mem_type`=$civi_member_type, `current_rule`='$current_rule',`expiry_rule`='$expiry_rule', `expire_wp_role`='$expired_wp_role'" );  
+        $wpdb->civi_member_sync = $wpdb->prefix . 'civi_member_sync';
+        $insert = $wpdb->get_results($wpdb->prepare("REPLACE INTO  $wpdb->civi_member_sync SET `wp_role`= %s, `civi_mem_type`= %d, `current_rule`= %s,`expiry_rule`= %s, `expire_wp_role`= %s", array($wp_role, $civi_member_type, $current_rule, $expiry_rule, $expired_wp_role) ) ) ;  
         
        $location = get_bloginfo('url')."/wp-admin/options-general.php?page=civi_member_sync/list.php";
         echo "<meta http-equiv='refresh' content='0;url=$location' />";exit;


### PR DESCRIPTION
Update plugin for proper use of $wpdb class.  Use $wpdb->prepare
throughout plugin.  Clean up and remove comments and debug code.  Update
version number
